### PR TITLE
4 metadata publisher

### DIFF
--- a/cmd/metadata-pub/main.go
+++ b/cmd/metadata-pub/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"datasource/pkg/metadatasim"
+)
+
+func main() {
+	output := flag.String("output", "./data/devices-metadata.json", "Path to metadata output file")
+	deviceCount := flag.Int("devices", 10, "Number of devices to generate")
+	updates := flag.Int("updates", 0, "Number of metadata update cycles (0 = none)")
+	updateInterval := flag.Duration("update-interval", 30*time.Second, "Time between metadata updates")
+
+	flag.Parse()
+
+	cfg := metadatasim.Config{
+		OutputPath:     *output,
+		DeviceCount:    *deviceCount,
+		Updates:        *updates,
+		UpdateInterval: *updateInterval,
+	}
+
+	fmt.Printf("Starting metadata publisher: devices=%d, output=%s, updates=%d, interval=%s\n",
+		cfg.DeviceCount, cfg.OutputPath, cfg.Updates, cfg.UpdateInterval)
+
+	if err := metadatasim.Run(cfg); err != nil {
+		log.Fatalf("metadata publisher failed: %v", err)
+	}
+}

--- a/data/devices-metadata.json
+++ b/data/devices-metadata.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "dev-001",
+    "hostname": "device-001",
+    "ip": "10.245.116.0",
+    "vendor": "Cisco",
+    "model": "ISR-4000",
+    "os": "IOS-XE 17.3",
+    "location": "DC1-Rack1",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-002",
+    "hostname": "device-002",
+    "ip": "10.69.131.228",
+    "vendor": "Huawei",
+    "model": "NE40E",
+    "os": "VRP 8.200",
+    "location": "DC1-Rack2",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-003",
+    "hostname": "device-003",
+    "ip": "10.62.171.197",
+    "vendor": "Cisco",
+    "model": "ISR-4000",
+    "os": "IOS-XE 17.3",
+    "location": "DC2-Rack5",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-004",
+    "hostname": "device-004",
+    "ip": "10.141.45.13",
+    "vendor": "Juniper",
+    "model": "MX480",
+    "os": "JUNOS 21.1",
+    "location": "DC1-Rack1",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-005",
+    "hostname": "device-005",
+    "ip": "10.173.193.45",
+    "vendor": "Cisco",
+    "model": "ISR-4000",
+    "os": "IOS-XE 17.3",
+    "location": "Branch-Delhi",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-006",
+    "hostname": "device-006",
+    "ip": "10.149.99.179",
+    "vendor": "Huawei",
+    "model": "NE40E",
+    "os": "VRP 8.200",
+    "location": "Branch-Delhi",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-007",
+    "hostname": "device-007",
+    "ip": "10.180.93.48",
+    "vendor": "Huawei",
+    "model": "NE40E",
+    "os": "VRP 8.200",
+    "location": "DC1-Rack1",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-008",
+    "hostname": "device-008",
+    "ip": "10.197.185.49",
+    "vendor": "Arista",
+    "model": "7050X3",
+    "os": "EOS 4.28",
+    "location": "DC1-Rack1",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-009",
+    "hostname": "device-009",
+    "ip": "10.190.93.210",
+    "vendor": "Cisco",
+    "model": "ISR-4000",
+    "os": "IOS-XE 17.3",
+    "location": "Branch-Delhi",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-010",
+    "hostname": "device-010",
+    "ip": "10.84.231.238",
+    "vendor": "Cisco",
+    "model": "ISR-4000",
+    "os": "IOS-XE 17.3",
+    "location": "Branch-Delhi",
+    "updated_at": "2025-12-10T17:55:10Z"
+  }
+]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module datasource
+
+go 1.25.4

--- a/pkg/metadatasim/publisher.go
+++ b/pkg/metadatasim/publisher.go
@@ -1,0 +1,137 @@
+package metadatasim
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Device represents metadata about a network device.
+type Device struct {
+	ID        string `json:"id"`
+	Hostname  string `json:"hostname"`
+	IP        string `json:"ip"`
+	Vendor    string `json:"vendor"`
+	Model     string `json:"model"`
+	OS        string `json:"os"`
+	Location  string `json:"location"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// Config controls how metadata is generated and written.
+type Config struct {
+	OutputPath     string        // where to write the shared metadata file
+	DeviceCount    int           // how many devices to generate
+	Updates        int           // how many times to update metadata (0 = no updates)
+	UpdateInterval time.Duration // delay between updates
+}
+
+// Run generates sample metadata and writes it to a common file.
+// Optionally performs a few update cycles to simulate changes.
+func Run(cfg Config) error {
+	rand.Seed(time.Now().UnixNano())
+
+	// Ensure the output directory exists.
+	dir := filepath.Dir(cfg.OutputPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create metadata directory: %w", err)
+	}
+
+	// Initial metadata generation.
+	devices := generateDevices(cfg.DeviceCount)
+	if err := writeDevices(cfg.OutputPath, devices); err != nil {
+		return err
+	}
+
+	fmt.Printf("Initial metadata for %d devices written to %s\n", cfg.DeviceCount, cfg.OutputPath)
+
+	// Optional update cycles.
+	for i := 0; i < cfg.Updates; i++ {
+		time.Sleep(cfg.UpdateInterval)
+
+		updateRandomDevice(devices)
+		if err := writeDevices(cfg.OutputPath, devices); err != nil {
+			return err
+		}
+		fmt.Printf("Metadata update %d written to %s\n", i+1, cfg.OutputPath)
+	}
+
+	return nil
+}
+
+// generateDevices creates a slice of fake devices.
+func generateDevices(count int) []Device {
+	vendors := []string{"Cisco", "Juniper", "Arista", "Huawei"}
+	models := []string{"ISR-4000", "MX480", "7050X3", "NE40E"}
+	oses := []string{"IOS-XE 17.3", "JUNOS 21.1", "EOS 4.28", "VRP 8.200"}
+	locations := []string{
+		"DC1-Rack1",
+		"DC1-Rack2",
+		"DC2-Rack5",
+		"Branch-Mumbai",
+		"Branch-Delhi",
+	}
+
+	devices := make([]Device, 0, count)
+
+	for i := 0; i < count; i++ {
+		vendorIdx := rand.Intn(len(vendors))
+		now := time.Now().UTC().Format(time.RFC3339)
+
+		d := Device{
+			ID:        fmt.Sprintf("dev-%03d", i+1),
+			Hostname:  fmt.Sprintf("device-%03d", i+1),
+			IP:        randomIP(),
+			Vendor:    vendors[vendorIdx],
+			Model:     models[vendorIdx],
+			OS:        oses[vendorIdx],
+			Location:  locations[rand.Intn(len(locations))],
+			UpdatedAt: now,
+		}
+
+		devices = append(devices, d)
+	}
+
+	return devices
+}
+
+// writeDevices writes the devices slice as pretty JSON to the given path.
+func writeDevices(path string, devices []Device) error {
+	data, err := json.MarshalIndent(devices, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write metadata file: %w", err)
+	}
+
+	return nil
+}
+
+// updateRandomDevice simulates a metadata change on a random device.
+func updateRandomDevice(devices []Device) {
+	if len(devices) == 0 {
+		return
+	}
+
+	idx := rand.Intn(len(devices))
+	dev := &devices[idx]
+
+	// Randomly change OS or Location to simulate drift.
+	switch rand.Intn(2) {
+	case 0:
+		dev.OS = dev.OS + " (patched)"
+	default:
+		dev.Location = dev.Location + "-Alt"
+	}
+
+	dev.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+}
+
+func randomIP() string {
+	return fmt.Sprintf("10.%d.%d.%d", rand.Intn(256), rand.Intn(256), rand.Intn(256))
+}


### PR DESCRIPTION
**Implemented a Metadata Publisher in Go.**
- It generates sample device metadata (hostname, IP, vendor, model, OS, location) and writes it into data/devices-_metadata.json._
- Optional flags allow updating metadata during simulation.
- Currently, this shares metadata through a common file as mentioned in the issue. REST submission will be added later.