### PR TITLE
Add SNMP trap generator

### DIFF
--- a/cmd/metadata-pub/main.go
+++ b/cmd/metadata-pub/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"datasource/pkg/metadatasim"
+)
+
+func main() {
+	output := flag.String("output", "./data/devices-metadata.json", "Path to metadata output file")
+	deviceCount := flag.Int("devices", 10, "Number of devices to generate")
+	updates := flag.Int("updates", 0, "Number of metadata update cycles (0 = none)")
+	updateInterval := flag.Duration("update-interval", 30*time.Second, "Time between metadata updates")
+
+	flag.Parse()
+
+	cfg := metadatasim.Config{
+		OutputPath:     *output,
+		DeviceCount:    *deviceCount,
+		Updates:        *updates,
+		UpdateInterval: *updateInterval,
+	}
+
+	fmt.Printf("Starting metadata publisher: devices=%d, output=%s, updates=%d, interval=%s\n",
+		cfg.DeviceCount, cfg.OutputPath, cfg.Updates, cfg.UpdateInterval)
+
+	if err := metadatasim.Run(cfg); err != nil {
+		log.Fatalf("metadata publisher failed: %v", err)
+	}
+}

--- a/cmd/snmp-trap-listener/main.go
+++ b/cmd/snmp-trap-listener/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"net"
+)
+
+func main() {
+	addr, _ := net.ResolveUDPAddr("udp", ":5162")
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		panic(err)
+	}
+	defer conn.Close()
+
+	fmt.Println("Listening for SNMP traps on UDP :5162")
+
+	buf := make([]byte, 4096)
+
+	for {
+		n, remote, _ := conn.ReadFromUDP(buf)
+		fmt.Printf("From %s:\n%s\n\n", remote, string(buf[:n]))
+	}
+}

--- a/cmd/snmp-trap-sim/main.go
+++ b/cmd/snmp-trap-sim/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"datasource/pkg/snmptrap"
+)
+
+func main() {
+	addr := flag.String("addr", "localhost:5162", "UDP address")
+	device := flag.String("device", "router", "router|switch|firewall")
+	freq := flag.Int("freq", 3, "seconds between traps")
+	flag.Parse()
+
+	rand.Seed(time.Now().UnixNano())
+
+	fmt.Printf("Starting SNMP trap simulator (%s) → %s\n", *device, *addr)
+
+	for {
+		trap := snmptrap.RandomTrap(*device, "device-01")
+		err := snmptrap.SendTrap(*addr, trap)
+		if err != nil {
+			fmt.Println("failed to send trap:", err)
+		} else {
+			fmt.Println("sent trap:", trap.OID, "-", trap.Message)
+		}
+		time.Sleep(time.Duration(*freq) * time.Second)
+	}
+}

--- a/cmd/snmp-trap-sim/main.go
+++ b/cmd/snmp-trap-sim/main.go
@@ -13,6 +13,7 @@ func main() {
 	addr := flag.String("addr", "localhost:5162", "UDP address")
 	device := flag.String("device", "router", "router|switch|firewall")
 	freq := flag.Int("freq", 3, "seconds between traps")
+	file := flag.String("file", "data/snmp-traps.json", "file to store traps")
 	flag.Parse()
 
 	rand.Seed(time.Now().UnixNano())
@@ -21,12 +22,21 @@ func main() {
 
 	for {
 		trap := snmptrap.RandomTrap(*device, "device-01")
+
+		// Send over UDP
 		err := snmptrap.SendTrap(*addr, trap)
 		if err != nil {
 			fmt.Println("failed to send trap:", err)
 		} else {
 			fmt.Println("sent trap:", trap.OID, "-", trap.Message)
 		}
+
+		// Save to JSON file
+		err = snmptrap.SaveTrapToFile(*file, trap)
+		if err != nil {
+			fmt.Println("failed to save trap:", err)
+		}
+
 		time.Sleep(time.Duration(*freq) * time.Second)
 	}
 }

--- a/data/devices-metadata.json
+++ b/data/devices-metadata.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "dev-001",
+    "hostname": "device-001",
+    "ip": "10.245.116.0",
+    "vendor": "Cisco",
+    "model": "ISR-4000",
+    "os": "IOS-XE 17.3",
+    "location": "DC1-Rack1",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-002",
+    "hostname": "device-002",
+    "ip": "10.69.131.228",
+    "vendor": "Huawei",
+    "model": "NE40E",
+    "os": "VRP 8.200",
+    "location": "DC1-Rack2",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-003",
+    "hostname": "device-003",
+    "ip": "10.62.171.197",
+    "vendor": "Cisco",
+    "model": "ISR-4000",
+    "os": "IOS-XE 17.3",
+    "location": "DC2-Rack5",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-004",
+    "hostname": "device-004",
+    "ip": "10.141.45.13",
+    "vendor": "Juniper",
+    "model": "MX480",
+    "os": "JUNOS 21.1",
+    "location": "DC1-Rack1",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-005",
+    "hostname": "device-005",
+    "ip": "10.173.193.45",
+    "vendor": "Cisco",
+    "model": "ISR-4000",
+    "os": "IOS-XE 17.3",
+    "location": "Branch-Delhi",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-006",
+    "hostname": "device-006",
+    "ip": "10.149.99.179",
+    "vendor": "Huawei",
+    "model": "NE40E",
+    "os": "VRP 8.200",
+    "location": "Branch-Delhi",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-007",
+    "hostname": "device-007",
+    "ip": "10.180.93.48",
+    "vendor": "Huawei",
+    "model": "NE40E",
+    "os": "VRP 8.200",
+    "location": "DC1-Rack1",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-008",
+    "hostname": "device-008",
+    "ip": "10.197.185.49",
+    "vendor": "Arista",
+    "model": "7050X3",
+    "os": "EOS 4.28",
+    "location": "DC1-Rack1",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-009",
+    "hostname": "device-009",
+    "ip": "10.190.93.210",
+    "vendor": "Cisco",
+    "model": "ISR-4000",
+    "os": "IOS-XE 17.3",
+    "location": "Branch-Delhi",
+    "updated_at": "2025-12-10T17:55:10Z"
+  },
+  {
+    "id": "dev-010",
+    "hostname": "device-010",
+    "ip": "10.84.231.238",
+    "vendor": "Cisco",
+    "model": "ISR-4000",
+    "os": "IOS-XE 17.3",
+    "location": "Branch-Delhi",
+    "updated_at": "2025-12-10T17:55:10Z"
+  }
+]

--- a/data/snmp-traps.json
+++ b/data/snmp-traps.json
@@ -1,0 +1,275 @@
+[
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.4",
+    "source": "device-01",
+    "message": "Interface up",
+    "severity": "info",
+    "timestamp": "2025-12-19T15:32:13.358047468Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.4",
+    "source": "device-01",
+    "message": "Interface up",
+    "severity": "info",
+    "timestamp": "2025-12-19T15:32:16.360793353Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.4.1.9.2.1.57",
+    "source": "device-01",
+    "message": "High CPU utilization",
+    "severity": "warning",
+    "timestamp": "2025-12-19T15:32:19.363456564Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.4.1.9.2.1.57",
+    "source": "device-01",
+    "message": "High CPU utilization",
+    "severity": "warning",
+    "timestamp": "2025-12-19T15:32:22.364961512Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.3",
+    "source": "device-01",
+    "message": "Interface down",
+    "severity": "critical",
+    "timestamp": "2025-12-19T15:32:25.365745845Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.4",
+    "source": "device-01",
+    "message": "Interface up",
+    "severity": "info",
+    "timestamp": "2025-12-19T15:32:28.366666302Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.3",
+    "source": "device-01",
+    "message": "Interface down",
+    "severity": "critical",
+    "timestamp": "2025-12-19T15:32:31.369474655Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.4",
+    "source": "device-01",
+    "message": "Interface up",
+    "severity": "info",
+    "timestamp": "2025-12-19T15:32:34.371515474Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.4.1.9.2.1.57",
+    "source": "device-01",
+    "message": "High CPU utilization",
+    "severity": "warning",
+    "timestamp": "2025-12-19T15:32:37.373297218Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.3",
+    "source": "device-01",
+    "message": "Interface down",
+    "severity": "critical",
+    "timestamp": "2025-12-19T15:32:40.374324526Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.4.1.9.2.1.57",
+    "source": "device-01",
+    "message": "High CPU utilization",
+    "severity": "warning",
+    "timestamp": "2025-12-19T15:32:43.377153444Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.4.1.9.2.1.57",
+    "source": "device-01",
+    "message": "High CPU utilization",
+    "severity": "warning",
+    "timestamp": "2025-12-19T15:32:46.379813479Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.4",
+    "source": "device-01",
+    "message": "Interface up",
+    "severity": "info",
+    "timestamp": "2025-12-19T15:32:49.381915214Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.4",
+    "source": "device-01",
+    "message": "Interface up",
+    "severity": "info",
+    "timestamp": "2025-12-19T15:32:52.384621555Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.3",
+    "source": "device-01",
+    "message": "Interface down",
+    "severity": "critical",
+    "timestamp": "2025-12-19T15:32:55.386403559Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.4",
+    "source": "device-01",
+    "message": "Interface up",
+    "severity": "info",
+    "timestamp": "2025-12-19T15:32:58.387414406Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.4",
+    "source": "device-01",
+    "message": "Interface up",
+    "severity": "info",
+    "timestamp": "2025-12-19T15:33:01.390334545Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.3",
+    "source": "device-01",
+    "message": "Interface down",
+    "severity": "critical",
+    "timestamp": "2025-12-19T15:33:04.393988548Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.3",
+    "source": "device-01",
+    "message": "Interface down",
+    "severity": "critical",
+    "timestamp": "2025-12-19T15:33:07.396801218Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.6.3.1.1.5.4",
+    "source": "device-01",
+    "message": "Interface up",
+    "severity": "info",
+    "timestamp": "2025-12-19T15:33:10.3997057Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  },
+  {
+    "version": "v2c",
+    "community": "public",
+    "oid": "1.3.6.1.4.1.9.2.1.57",
+    "source": "device-01",
+    "message": "High CPU utilization",
+    "severity": "warning",
+    "timestamp": "2025-12-19T15:33:13.402582558Z",
+    "variables": {
+      "ifIndex": "1",
+      "value": "threshold-crossed"
+    }
+  }
+]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module datasource
+
+go 1.25.4

--- a/pkg/metadatasim/publisher.go
+++ b/pkg/metadatasim/publisher.go
@@ -1,0 +1,137 @@
+package metadatasim
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Device represents metadata about a network device.
+type Device struct {
+	ID        string `json:"id"`
+	Hostname  string `json:"hostname"`
+	IP        string `json:"ip"`
+	Vendor    string `json:"vendor"`
+	Model     string `json:"model"`
+	OS        string `json:"os"`
+	Location  string `json:"location"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// Config controls how metadata is generated and written.
+type Config struct {
+	OutputPath     string        // where to write the shared metadata file
+	DeviceCount    int           // how many devices to generate
+	Updates        int           // how many times to update metadata (0 = no updates)
+	UpdateInterval time.Duration // delay between updates
+}
+
+// Run generates sample metadata and writes it to a common file.
+// Optionally performs a few update cycles to simulate changes.
+func Run(cfg Config) error {
+	rand.Seed(time.Now().UnixNano())
+
+	// Ensure the output directory exists.
+	dir := filepath.Dir(cfg.OutputPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create metadata directory: %w", err)
+	}
+
+	// Initial metadata generation.
+	devices := generateDevices(cfg.DeviceCount)
+	if err := writeDevices(cfg.OutputPath, devices); err != nil {
+		return err
+	}
+
+	fmt.Printf("Initial metadata for %d devices written to %s\n", cfg.DeviceCount, cfg.OutputPath)
+
+	// Optional update cycles.
+	for i := 0; i < cfg.Updates; i++ {
+		time.Sleep(cfg.UpdateInterval)
+
+		updateRandomDevice(devices)
+		if err := writeDevices(cfg.OutputPath, devices); err != nil {
+			return err
+		}
+		fmt.Printf("Metadata update %d written to %s\n", i+1, cfg.OutputPath)
+	}
+
+	return nil
+}
+
+// generateDevices creates a slice of fake devices.
+func generateDevices(count int) []Device {
+	vendors := []string{"Cisco", "Juniper", "Arista", "Huawei"}
+	models := []string{"ISR-4000", "MX480", "7050X3", "NE40E"}
+	oses := []string{"IOS-XE 17.3", "JUNOS 21.1", "EOS 4.28", "VRP 8.200"}
+	locations := []string{
+		"DC1-Rack1",
+		"DC1-Rack2",
+		"DC2-Rack5",
+		"Branch-Mumbai",
+		"Branch-Delhi",
+	}
+
+	devices := make([]Device, 0, count)
+
+	for i := 0; i < count; i++ {
+		vendorIdx := rand.Intn(len(vendors))
+		now := time.Now().UTC().Format(time.RFC3339)
+
+		d := Device{
+			ID:        fmt.Sprintf("dev-%03d", i+1),
+			Hostname:  fmt.Sprintf("device-%03d", i+1),
+			IP:        randomIP(),
+			Vendor:    vendors[vendorIdx],
+			Model:     models[vendorIdx],
+			OS:        oses[vendorIdx],
+			Location:  locations[rand.Intn(len(locations))],
+			UpdatedAt: now,
+		}
+
+		devices = append(devices, d)
+	}
+
+	return devices
+}
+
+// writeDevices writes the devices slice as pretty JSON to the given path.
+func writeDevices(path string, devices []Device) error {
+	data, err := json.MarshalIndent(devices, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write metadata file: %w", err)
+	}
+
+	return nil
+}
+
+// updateRandomDevice simulates a metadata change on a random device.
+func updateRandomDevice(devices []Device) {
+	if len(devices) == 0 {
+		return
+	}
+
+	idx := rand.Intn(len(devices))
+	dev := &devices[idx]
+
+	// Randomly change OS or Location to simulate drift.
+	switch rand.Intn(2) {
+	case 0:
+		dev.OS = dev.OS + " (patched)"
+	default:
+		dev.Location = dev.Location + "-Alt"
+	}
+
+	dev.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+}
+
+func randomIP() string {
+	return fmt.Sprintf("10.%d.%d.%d", rand.Intn(256), rand.Intn(256), rand.Intn(256))
+}

--- a/pkg/snmptrap/generator.go
+++ b/pkg/snmptrap/generator.go
@@ -1,0 +1,48 @@
+package snmptrap
+
+import (
+	"math/rand"
+	"time"
+)
+
+type Trap struct {
+	Version   string            `json:"version"`
+	Community string            `json:"community"`
+	OID       string            `json:"oid"`
+	Source    string            `json:"source"`
+	Message   string            `json:"message"`
+	Severity  string            `json:"severity"`
+	Timestamp time.Time         `json:"timestamp"`
+	Variables map[string]string `json:"variables"`
+}
+
+func RandomTrap(deviceType string, source string) Trap {
+	var templates []TrapTemplate
+
+	switch deviceType {
+	case "router":
+		templates = RouterTraps
+	case "switch":
+		templates = SwitchTraps
+	case "firewall":
+		templates = FirewallTraps
+	default:
+		templates = RouterTraps
+	}
+
+	t := templates[rand.Intn(len(templates))]
+
+	return Trap{
+		Version:   "v2c",
+		Community: "public",
+		OID:       t.OID,
+		Source:    source,
+		Message:   t.Message,
+		Severity:  t.Severity,
+		Timestamp: time.Now().UTC(),
+		Variables: map[string]string{
+			"ifIndex": "1",
+			"value":   "threshold-crossed",
+		},
+	}
+}

--- a/pkg/snmptrap/sender.go
+++ b/pkg/snmptrap/sender.go
@@ -1,0 +1,22 @@
+package snmptrap
+
+import (
+	"encoding/json"
+	"net"
+)
+
+func SendTrap(addr string, trap Trap) error {
+	conn, err := net.Dial("udp", addr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	data, err := json.Marshal(trap)
+	if err != nil {
+		return err
+	}
+
+	_, err = conn.Write(data)
+	return err
+}

--- a/pkg/snmptrap/store.go
+++ b/pkg/snmptrap/store.go
@@ -1,0 +1,33 @@
+package snmptrap
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+)
+
+var fileLock sync.Mutex
+
+func SaveTrapToFile(path string, trap Trap) error {
+	fileLock.Lock()
+	defer fileLock.Unlock()
+
+	var traps []Trap
+
+	// Read existing file
+	data, err := os.ReadFile(path)
+	if err == nil && len(data) > 0 {
+		_ = json.Unmarshal(data, &traps)
+	}
+
+	// Append new trap
+	traps = append(traps, trap)
+
+	// Write back
+	out, err := json.MarshalIndent(traps, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, out, 0644)
+}

--- a/pkg/snmptrap/templates.go
+++ b/pkg/snmptrap/templates.go
@@ -1,0 +1,22 @@
+package snmptrap
+
+type TrapTemplate struct {
+	OID      string
+	Message  string
+	Severity string
+}
+
+var RouterTraps = []TrapTemplate{
+	{"1.3.6.1.6.3.1.1.5.3", "Interface down", "critical"},
+	{"1.3.6.1.6.3.1.1.5.4", "Interface up", "info"},
+	{"1.3.6.1.4.1.9.2.1.57", "High CPU utilization", "warning"},
+}
+
+var SwitchTraps = []TrapTemplate{
+	{"1.3.6.1.4.1.9.9.13.3.1.3", "Port security violation", "error"},
+	{"1.3.6.1.4.1.9.9.46.2.1.1", "Spanning tree topology change", "warning"},
+}
+
+var FirewallTraps = []TrapTemplate{
+	{"1.3.6.1.4.1.9.9.147.1.2", "Firewall authentication failure", "critical"},
+}

--- a/pkg/snmptrap/udplisten.go
+++ b/pkg/snmptrap/udplisten.go
@@ -1,0 +1,24 @@
+package snmptrap
+
+import (
+	"fmt"
+	"net"
+)
+
+func testListen() {
+	addr, _ := net.ResolveUDPAddr("udp", ":5162")
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		panic(err)
+	}
+	defer conn.Close()
+
+	fmt.Println("Listening for SNMP traps on UDP :5162")
+
+	buf := make([]byte, 4096)
+
+	for {
+		n, remote, _ := conn.ReadFromUDP(buf)
+		fmt.Printf("From %s:\n%s\n\n", remote, string(buf[:n]))
+	}
+}


### PR DESCRIPTION
**Added an SNMP trap simulator written in Go.**

The module simulates SNMP v2c-style traps using predefined templates for routers, switches, and firewalls. Traps are generated at configurable intervals and sent over UDP to simulate device alerts to the Ingestor.

**Features:**
- SNMP v2c trap simulation
- Template-based traps for different device types
- Random trap generation
- Configurable frequency and device type
- UDP transport

<img width="1227" height="1033" alt="image_2025-12-19_210827271" src="https://github.com/user-attachments/assets/089cfeb9-d517-4fce-b31b-bfddfd4ae9bb" />
Optional JSON persistence for generated traps

- **The simulator was tested locally using a UDP listener.**